### PR TITLE
Programmer/hotfix/スクラッチでエネルギー減らないようにする（他）

### DIFF
--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
@@ -331,6 +331,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8030262654354652867, guid: fa3dd35a5b9f8764db1da1ca923e54f9, type: 3}
+      propertyPath: updateCorrected.Array.data[0]
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030262654354652867, guid: fa3dd35a5b9f8764db1da1ca923e54f9, type: 3}
+      propertyPath: updateCorrected.Array.data[1]
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030262654354652867, guid: fa3dd35a5b9f8764db1da1ca923e54f9, type: 3}
+      propertyPath: updateCorrectedMidiJack.Array.data[0]
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030262654354652867, guid: fa3dd35a5b9f8764db1da1ca923e54f9, type: 3}
+      propertyPath: updateCorrectedMidiJack.Array.data[1]
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/InputSlipLoopState.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/InputSlipLoopState.cs
@@ -59,6 +59,7 @@ namespace Main.Common
                 BeatLength.OneBeat => baseValue * 1f,
                 BeatLength.HalfBeat => baseValue * .5f,
                 BeatLength.QuarterBeat => baseValue * .25f,
+                BeatLength.None => baseValue * 0f,
                 _ => throw new System.ArgumentOutOfRangeException($"指定不可の条件:[{(BeatLength)inputSlipLoopState.beatLength.Value}]"),
             };
         }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/InputSlipLoopState.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/InputSlipLoopState.cs
@@ -59,7 +59,6 @@ namespace Main.Common
                 BeatLength.OneBeat => baseValue * 1f,
                 BeatLength.HalfBeat => baseValue * .5f,
                 BeatLength.QuarterBeat => baseValue * .25f,
-                BeatLength.None => baseValue * 0f,
                 _ => throw new System.ArgumentOutOfRangeException($"指定不可の条件:[{(BeatLength)inputSlipLoopState.beatLength.Value}]"),
             };
         }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/JockeyCommandType.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/JockeyCommandType.cs
@@ -19,5 +19,7 @@ namespace Main.Common
         BackSpin,
         /// <summary>スリップループ</summary>
         SlipLoop,
+        /// <summary>スリップループ</summary>
+        SlipLoopEnd,
     }    
 }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/PentagramSystemModel.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/PentagramSystemModel.cs
@@ -67,7 +67,7 @@ namespace Main.Model
             this.UpdateAsObservable()
                 .Subscribe(_ =>
                 {
-                    if (inputSlipLoopState.IsLooping.Value)
+                    if (inputSlipLoopState.IsLooping.Value && (BeatLength)inputSlipLoopState.beatLength.Value != BeatLength.None)
                     {
                         var limit = BeatLengthApp.GetTotalReverse(inputSlipLoopState, audioOwner.GetBeatBGM());
                         if (limit <= elapsedTime.Value)

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/PentagramSystemModel.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/PentagramSystemModel.cs
@@ -106,6 +106,15 @@ namespace Main.Model
                         inputSlipLoopState.IsLooping.Value = true;
 
                         break;
+                    case Common.JockeyCommandType.Scratch:
+
+                        break;
+                    case Common.JockeyCommandType.Hold:
+
+                        break;
+                    case Common.JockeyCommandType.None:
+
+                        break;
                     default:
                         inputSlipLoopState.IsLooping.Value = false;
 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Presenter/MainPresenter.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Presenter/MainPresenter.cs
@@ -620,6 +620,9 @@ namespace Main.Presenter
                         Debug.LogError("UpdateCandleResource");
                     if (!pentagramTurnTableModel.BuffAllTurrets((JockeyCommandType)pair.Current))
                         Debug.LogError("BuffAllTurrets");
+                    // バックスピンはSPゲージ回復中は無効
+                    if (!shikigamiSkillSystemModel.CandleInfo.isRest.Value)
+                    {
                     if (!shikigamiSkillSystemModel.ForceZeroAndRapidRecoveryCandleResource((JockeyCommandType)pair.Current))
                         Debug.LogError("ForceZeroAndRapidRecoveryCandleResource");
                     Observable.FromCoroutine<bool>(observer => pentagramTurnTableView.PlayDirectionBackSpin(observer, (JockeyCommandType)pair.Current))
@@ -629,6 +632,13 @@ namespace Main.Presenter
                                 Debug.LogError("ResetJockeyCommandType");
                         })
                         .AddTo(gameObject);
+                    }
+                    else
+                    {
+                        // バックスピンの呼び出しが無効の場合は、即座に入力状態をリセット
+                        if (!pentagramSystemModel.ResetJockeyCommandType())
+                            Debug.LogError("ResetJockeyCommandType");
+                    }
                     if (!pentagramSystemModel.SetIsLooping((JockeyCommandType)pair.Current))
                         Debug.LogError("SetIsLooping");
                     if (!shikigamiSkillSystemModel.SetIsStopRecovery((JockeyCommandType)pair.Current))

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Presenter/MainPresenter.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Presenter/MainPresenter.cs
@@ -608,9 +608,12 @@ namespace Main.Presenter
                 .Select(_ => pentagramSystemModel.InputValue)
                 .Subscribe(x =>
                 {
-                    bgmConfDetails.InputValue = x.Value;
-                    if (!pentagramTurnTableView.MoveSpin(bgmConfDetails))
-                        Debug.LogError("MoveSpin");
+                    if (!pentagramSystemModel.InputSlipLoopState.IsLooping.Value)
+                    {
+                        bgmConfDetails.InputValue = x.Value;
+                        if (!pentagramTurnTableView.MoveSpin(bgmConfDetails))
+                            Debug.LogError("MoveSpin");
+                    }
                 });
             pentagramSystemModel.JockeyCommandType.ObserveEveryValueChanged(x => x.Value)
                 .Pairwise()

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Utility/InputSystemUtility.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Utility/InputSystemUtility.cs
@@ -365,6 +365,10 @@ namespace Main.Utility
                         _modelUpdObservable.Dispose();
                         // 何もしない
                         break;
+                    case JockeyCommandType.SlipLoopEnd:
+                        _modelUpdObservable.Dispose();
+                        // 何もしない
+                        break;
                     default:
                         throw new System.Exception("未定義のジョッキーコマンドタイプ");
                 }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Utility/JockeyCommandUtility.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Utility/JockeyCommandUtility.cs
@@ -53,33 +53,37 @@ namespace Main.Utility
                 inputValue.ObserveEveryValueChanged(x => x.Value)
                     .Subscribe(value => 
                     {
-                        // 入力履歴が10を超えた場合、最初の要素を削除
-                        if (inputHistory.Count >= inputHistoriesLimit)
-                            inputHistory.RemoveAt(0);
-
-                        // 最後の入力と異なる場合のみ履歴に追加
-                        if (inputHistory.Count == 0 ||
-                            inputHistory[inputHistory.Count - 1] != value)
-                            inputHistory.Add(value);
-
-                        // 最後の入力が0の場合、jockeyCommandTypeをHoldに設定
-                        if (value == 0 ||
-                            isScratch(inputHistory, autoSpinSpeed))
+                        // ループ中ならスクラッチの入力を無視
+                        if (jockeyCommandType.Value != (int)JockeyCommandType.SlipLoop)
                         {
-                            if (value == 0)
-                                jockeyCommandType.Value = (int)JockeyCommandType.Hold;
-                            if (isScratch(inputHistory, autoSpinSpeed))
+                            // 入力履歴が10を超えた場合、最初の要素を削除
+                            if (inputHistory.Count >= inputHistoriesLimit)
+                                inputHistory.RemoveAt(0);
+
+                            // 最後の入力と異なる場合のみ履歴に追加
+                            if (inputHistory.Count == 0 ||
+                                inputHistory[inputHistory.Count - 1] != value)
+                                inputHistory.Add(value);
+
+                            // 最後の入力が0の場合、jockeyCommandTypeをHoldに設定
+                            if (value == 0 ||
+                                isScratch(inputHistory, autoSpinSpeed))
                             {
-                                jockeyCommandType.Value = (int)JockeyCommandType.Scratch;
+                                if (value == 0)
+                                    jockeyCommandType.Value = (int)JockeyCommandType.Hold;
+                                if (isScratch(inputHistory, autoSpinSpeed))
+                                {
+                                    jockeyCommandType.Value = (int)JockeyCommandType.Scratch;
+                                    if (0 < inputHistory.Count)
+                                        inputHistory.Clear();
+                                }
+                            }
+                            else if (value == autoSpinSpeed)
+                            {
+                                jockeyCommandType.Value = (int)JockeyCommandType.None;
                                 if (0 < inputHistory.Count)
                                     inputHistory.Clear();
                             }
-                        }
-                        else if (value == autoSpinSpeed)
-                        {
-                            jockeyCommandType.Value = (int)JockeyCommandType.None;
-                            if (0 < inputHistory.Count)
-                                inputHistory.Clear();
                         }
                     });
                 
@@ -202,7 +206,7 @@ namespace Main.Utility
                             if (differentCount % 2 == 0)
                             {
                                 inputSlipLoopState.beatLength.Value = (int)BeatLength.None;
-                                jockeyCommandType.Value = (int)JockeyCommandType.None;
+                                jockeyCommandType.Value = (int)JockeyCommandType.SlipLoopEnd;
                                 inputSlipLoopState.crossVectorHistory.Clear();
                             }
                             else


### PR DESCRIPTION
細かいのが多いので、下記４件まとめてコミット＆プルリクエスト
個別の修正内容は差分内容を確認するか、要件一覧から確認ください。
・スクラッチでエネルギー減らないようにする
・回復中にバックスピンをできないようにする（動きバグってるので）
・ループ操作中、スクラッチをしてもループキャンセルしないようにする
・ループ解除の度にエラーが出る