### PR TITLE
ステージ開始時に報酬選択画面が見えないよう修正

### DIFF
--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
@@ -1225,6 +1225,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a227817a1e918074f94faa2545611a02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &2040332958 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6942575347331565255, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+  m_PrefabInstance: {fileID: 3116255076235499502}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2094762496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2162,6 +2167,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3116255076115935084, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 50
+      objectReference: {fileID: 0}
     - target: {fileID: 3116255076128009727, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2406,6 +2415,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3116255076751476635, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+      propertyPath: targetRectTransform
+      value: 
+      objectReference: {fileID: 2040332958}
     - target: {fileID: 3116255076767530538, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2869,6 +2882,10 @@ PrefabInstance:
     - target: {fileID: 6719368663526017881, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6942575347331565255, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1000
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/ClearView.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/ClearView.cs
@@ -13,6 +13,7 @@ namespace Main.View
     {
         /// <summary>クリア結果のコンテンツ</summary>
         [SerializeField] private ClearResultContents[] clearResultContents;
+        [SerializeField] public RectTransform targetRectTransform;
 
         private void Reset()
         {
@@ -77,6 +78,9 @@ namespace Main.View
             try
             {
                 gameObject.SetActive(active);
+
+                if (active)
+                    targetRectTransform.anchoredPosition = Vector2.zero;
 
                 return true;
             }


### PR DESCRIPTION
・ステージ開始時は、報酬選択画面を画面外（Y座標を1000）に設定
・ステージクリア時に、Y座標を０に設定