### PR TITLE
▼UI・サウンド

### DIFF
--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Canvas.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Canvas.prefab
@@ -1879,6 +1879,7 @@ RectTransform:
   - {fileID: 5012020046326967509}
   - {fileID: 338351915586105363}
   - {fileID: 3116255076751476639}
+  - {fileID: 1295699972695289177}
   - {fileID: 3116255075549509127}
   - {fileID: 3341810793645040758}
   - {fileID: 3116255077101535003}
@@ -11026,6 +11027,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -91
       objectReference: {fileID: 0}
+    - target: {fileID: 4455790506874201939, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
+      propertyPath: targetRectTransform
+      value: 
+      objectReference: {fileID: 6942575347331565255}
     - target: {fileID: 4455790506874201942, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
       propertyPath: m_Name
       value: Clear
@@ -11124,7 +11129,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4455790507446570916, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 85
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4455790507446570917, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
       propertyPath: m_Navigation.m_SelectOnUp
@@ -11238,6 +11243,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 109
       objectReference: {fileID: 0}
+    - target: {fileID: 8552889701291910671, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1000
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -11257,6 +11266,11 @@ MonoBehaviour:
 --- !u!224 &3116255076751476639 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4455790506874201943, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
+  m_PrefabInstance: {fileID: 1650864623979389128}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6942575347331565255 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8552889701291910671, guid: f9df1c95592bcb047833a0eb220ee79d, type: 3}
   m_PrefabInstance: {fileID: 1650864623979389128}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1761972364009804254
@@ -11596,6 +11610,108 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3195091144400336747, guid: 644c4ff0c3262d845b837b9352bbe29b, type: 3}
   m_PrefabInstance: {fileID: 2946813422566590328}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3217527089607083016
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3116255075719936863}
+    m_Modifications:
+    - target: {fileID: 3165956910654295595, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_Name
+      value: GameOver
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+--- !u!224 &1295699972695289177 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4421887864376551761, guid: b7da35f8fb424cf439803271f843657b, type: 3}
+  m_PrefabInstance: {fileID: 3217527089607083016}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3329814598686758302
 PrefabInstance:

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/EventSystemMidiJack.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/EventSystemMidiJack.prefab
@@ -48,3 +48,5 @@ MonoBehaviour:
   rewardSelectModel: {fileID: 0}
   unDeadTimeSec: 0.2
   sensibilityScratch: 5
+  gameSelectButtonModel: {fileID: 0}
+  gameTitleButtonModel: {fileID: 0}

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver.meta
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6e8e665d50f9544a974f9cd5f9607fc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver/GameOver.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver/GameOver.prefab
@@ -1,0 +1,391 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1547262744577076439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4070499295069648850}
+  - component: {fileID: 564452208165781172}
+  - component: {fileID: 3097231449225345338}
+  - component: {fileID: 283278816638039462}
+  - component: {fileID: 6830843453343355911}
+  - component: {fileID: 590151785479142414}
+  - component: {fileID: 6662109164175999055}
+  m_Layer: 5
+  m_Name: GameTitleButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4070499295069648850
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4421887864376551761}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -715.0084}
+  m_SizeDelta: {x: 608.4034, y: 146.0168}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &564452208165781172
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_CullTransparentMesh: 1
+--- !u!114 &3097231449225345338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 09e9dd8130ba89944b562c822111a563, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &283278816638039462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3097231449225345338}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6830843453343355911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 9
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 590151785479142414}
+          m_TargetAssemblyTypeName: Main.Model.UIEventController, Assembly-CSharp
+          m_MethodName: Selected
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 10
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 590151785479142414}
+          m_TargetAssemblyTypeName: Main.Model.UIEventController, Assembly-CSharp
+          m_MethodName: DeSelected
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 15
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 590151785479142414}
+          m_TargetAssemblyTypeName: Main.Model.UIEventController, Assembly-CSharp
+          m_MethodName: Submited
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 16
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 590151785479142414}
+          m_TargetAssemblyTypeName: Main.Model.UIEventController, Assembly-CSharp
+          m_MethodName: Canceled
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!114 &590151785479142414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eb34d1c3a6187842bead1e2cb27ae9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6662109164175999055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1547262744577076439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efcdb478d7bdd6a4fbd15c49489cd69b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3165956910654295595
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4421887864376551761}
+  - component: {fileID: 9126557913022150334}
+  - component: {fileID: 7140854006400660790}
+  - component: {fileID: 3819499137548699833}
+  m_Layer: 5
+  m_Name: GameOver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4421887864376551761
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165956910654295595}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1736525560072043551}
+  - {fileID: 4070499295069648850}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9126557913022150334
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165956910654295595}
+  m_CullTransparentMesh: 1
+--- !u!114 &7140854006400660790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165956910654295595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.39215687}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3819499137548699833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3165956910654295595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b54aa291512bcd040b52420755aa0c49, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8839386137619149229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1736525560072043551}
+  - component: {fileID: 8303704886962390029}
+  - component: {fileID: 5792246190101301544}
+  m_Layer: 5
+  m_Name: GameOverImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1736525560072043551
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839386137619149229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4421887864376551761}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -305.65588}
+  m_SizeDelta: {x: 813.4206, y: 235.892}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8303704886962390029
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839386137619149229}
+  m_CullTransparentMesh: 1
+--- !u!114 &5792246190101301544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8839386137619149229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 8458ebc3a984c8741861b7c8700ff2d3, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver/GameOver.prefab.meta
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/GameOver/GameOver.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7da35f8fb424cf439803271f843657b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/PentagramTurnTable.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/UI/PentagramTurnTable.prefab
@@ -96,9 +96,9 @@ MonoBehaviour:
   angleCorrectionValue: 5
   sprites:
   - {fileID: 21300000, guid: 8be1b76402ef6da4bb4f46d64944d704, type: 3}
-  - {fileID: 21300000, guid: e48c7f21ba7383049b171947d28fc2be, type: 3}
-  - {fileID: 21300000, guid: d18b9958235b44f40a30b9205cd7960b, type: 3}
-  - {fileID: 21300000, guid: ced91dea13cb0bf468203a195203df12, type: 3}
+  - {fileID: 21300000, guid: 8be1b76402ef6da4bb4f46d64944d704, type: 3}
+  - {fileID: 21300000, guid: 8be1b76402ef6da4bb4f46d64944d704, type: 3}
+  - {fileID: 21300000, guid: 8be1b76402ef6da4bb4f46d64944d704, type: 3}
   backSpinCount: 5
   durations:
   - 1.5

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scenes/MainScene.unity
@@ -620,6 +620,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49aee100e030b7d4f870962a671fcdce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &877289120 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5054490273931460206, guid: 50fd406f81b583f49ae7057cbd79c812, type: 3}
+  m_PrefabInstance: {fileID: 937467245294446134}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a7b6135dd4767344bf7740909fe97a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &898339426 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3116255075506177420, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
@@ -748,6 +759,39 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6746740031984354500, guid: 8edce7cbca22a0c469d5ad2318da7245, type: 3}
   m_PrefabInstance: {fileID: 6746740031308020141}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1070523750 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8129669317830624327, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+  m_PrefabInstance: {fileID: 3116255076235499502}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efcdb478d7bdd6a4fbd15c49489cd69b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1070523751 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2636382846980323334, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+  m_PrefabInstance: {fileID: 3116255076235499502}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eb34d1c3a6187842bead1e2cb27ae9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1070523752 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1848558243303541937, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
+  m_PrefabInstance: {fileID: 3116255076235499502}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b54aa291512bcd040b52420755aa0c49, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1138058035
 GameObject:
   m_ObjectHideFlags: 0
@@ -1225,11 +1269,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a227817a1e918074f94faa2545611a02, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2040332958 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6942575347331565255, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
-  m_PrefabInstance: {fileID: 3116255076235499502}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2094762496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1326,9 +1365,9 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 656231433}
     - target: {fileID: 5054490273931460206, guid: 50fd406f81b583f49ae7057cbd79c812, type: 3}
-      propertyPath: gameRetryButtonModel
+      propertyPath: gameTitleButtonModel
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1070523751}
     - target: {fileID: 5054490273931460206, guid: 50fd406f81b583f49ae7057cbd79c812, type: 3}
       propertyPath: gameSelectButtonModel
       value: 
@@ -1407,6 +1446,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3116255076235499503}
     - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
+      propertyPath: gameOverView
+      value: 
+      objectReference: {fileID: 1070523752}
+    - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
       propertyPath: fadeImageView
       value: 
       objectReference: {fileID: 1854376149}
@@ -1459,6 +1502,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2094762497}
     - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
+      propertyPath: gameTitleButtonView
+      value: 
+      objectReference: {fileID: 1070523750}
+    - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
       propertyPath: levelBackgroundView
       value: 
       objectReference: {fileID: 6684895028120951196}
@@ -1474,6 +1521,10 @@ PrefabInstance:
       propertyPath: gameSelectButtonView
       value: 
       objectReference: {fileID: 434354311}
+    - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
+      propertyPath: gameTitleButtonModel
+      value: 
+      objectReference: {fileID: 1070523751}
     - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
       propertyPath: pentagramSystemModel
       value: 
@@ -1502,6 +1553,10 @@ PrefabInstance:
       propertyPath: pentagramTurnTableModel
       value: 
       objectReference: {fileID: 564062596}
+    - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
+      propertyPath: eventSystemMidiJackModel
+      value: 
+      objectReference: {fileID: 877289120}
     - target: {fileID: 1181800399, guid: 898ade031a3ce554b8df63abbf1da280, type: 3}
       propertyPath: shikigamiSkillSystemModel
       value: 
@@ -1761,27 +1816,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1280
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1000
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 960
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075542973558, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -540
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075602118371, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2013,27 +2068,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1280
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1000
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 4160
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075894307844, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -540
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255075921319740, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2114,10 +2169,6 @@ PrefabInstance:
     - target: {fileID: 3116255076025138236, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3116255076115935084, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076128009727, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2363,10 +2414,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3116255076751476635, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
-      propertyPath: targetRectTransform
-      value: 
-      objectReference: {fileID: 2040332958}
     - target: {fileID: 3116255076767530538, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2401,27 +2448,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1280
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1000
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 5760
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076795768505, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -540
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255076865136233, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2601,27 +2648,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1280
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1000
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 2560
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077294490977, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -540
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3116255077325487949, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2798,10 +2845,6 @@ PrefabInstance:
     - target: {fileID: 6719368663526017881, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6942575347331565255, guid: d1f02c59a59dc8a4d89245becc051b3d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 1000
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/AudioOwner.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/AudioOwner.cs
@@ -113,6 +113,11 @@ namespace Main.Audio
         {
             return bgmPlayer.SwitchClipNight();
         }
+
+        public void StopBGM()
+        {
+            bgmPlayer.StopBGM();
+        }
     }
 
     /// <summary>
@@ -192,6 +197,10 @@ namespace Main.Audio
         /// </summary>
         /// <param name="clipToPlay">BGM</param>
         public void PlayBGM(ClipToPlayBGM clipToPlay) { }
+        /// <summary>
+        /// BGMを止める
+        /// </summary>
+        public void StopBGM();
         /// <summary>
         /// BGMを再生
         /// ※ステージ開始時に呼ばれる

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/BgmPlayer.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/BgmPlayer.cs
@@ -251,6 +251,11 @@ namespace Main.Audio
                 return false;
             }
         }
+
+        public void StopBGM()
+        {
+            audioSource.Stop();
+        }
     }
 
     /// <summary>

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/SceneOwner.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Common/SceneOwner.cs
@@ -17,6 +17,8 @@ namespace Main.Common
         [SerializeField] private string nextSceneName = "MainScene";
         /// <summary>前のシーン名</summary>
         [SerializeField] private string backSceneName = "SelectScene";
+        /// <summary>タイトルのシーン名</summary>
+        [SerializeField] private string titleSceneName = "TitleScene";
 
         public void OnStart()
         {
@@ -92,6 +94,32 @@ namespace Main.Common
         }
 
         /// <summary>
+        /// ステージクリア済みデータの削除
+        /// </summary>
+        /// <returns>成功／失敗</returns>
+        public bool DestroyMainSceneStagesState()
+        {
+            try
+            {
+                var temp = new TemplateResourcesAccessory();
+                var bean = temp.LoadSaveDatasJsonOfUserBean(ConstResorcesNames.USER_DATA);
+                var beanDefault = temp.LoadSaveDatasJsonOfUserBean(ConstResorcesNames.USER_DATA, EnumLoadMode.Default);
+                var beanUpdate = temp.UpdateSceneStates(bean, beanDefault);
+                if (beanUpdate == null)
+                    throw new System.Exception("シーン更新の失敗");
+                if (!temp.SaveDatasJsonOfUserBean(ConstResorcesNames.USER_DATA, beanUpdate))
+                    throw new System.Exception("Json保存呼び出しの失敗");
+
+                return true;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError(e);
+                return false;
+            }
+        }
+
+        /// <summary>
         /// メインシーンをロード
         /// </summary>
         public void LoadMainScene()
@@ -106,9 +134,27 @@ namespace Main.Common
         {
             SceneManager.LoadScene(backSceneName);
         }
+
+
+        /// <summary>
+        /// タイトルシーンをロード
+        /// </summary>
+        public void LoadTitleScene()
+        {
+            SceneManager.LoadScene(titleSceneName);
+        }
     }
 
+    /// <summary>
+    /// シーンオーナー
+    /// インターフェース
+    /// </summary>
     public interface ISceneOwner
     {
+        /// <summary>
+        /// セーブデータをリセット
+        /// </summary>
+        /// <returns>成功／失敗</returns>
+        public bool DestroyMainSceneStagesState();
     }
 }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/EventSystemMidiJackModel.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/EventSystemMidiJackModel.cs
@@ -16,7 +16,7 @@ namespace Main.Model
     /// MIDIJack用
     /// イベントシステム
     /// </summary>
-    public class EventSystemMidiJackModel : MonoBehaviour
+    public class EventSystemMidiJackModel : MonoBehaviour, IEventSystemMidiJackModel
     {
         /// <summary>ポーズボタンのモデル</summary>
         [SerializeField] private GamePauseModel gamePauseModel;
@@ -28,12 +28,15 @@ namespace Main.Model
         [SerializeField] private float sensibilityScratch = 5f;
         /// <summary>ステージ選択へ戻るのモデル</summary>
         [SerializeField] private GameSelectButtonModel gameSelectButtonModel;
+        /// <summary>タイトルへ戻るボタン</summary>
+        [SerializeField] private GameTitleButtonModel gameTitleButtonModel;
 
         private void Reset()
         {
             gamePauseModel = GameObject.Find("GamePause").GetComponent<GamePauseModel>();
             rewardSelectModel = GameObject.Find("RewardSelect").GetComponent<RewardSelectModel>();
             gameSelectButtonModel = GameObject.Find("GameSelectButton").GetComponent<GameSelectButtonModel>();
+            gameTitleButtonModel = GameObject.Find("GameTitleButton").GetComponent<GameTitleButtonModel>();
         }
 
         private void Start()
@@ -67,6 +70,7 @@ namespace Main.Model
                     List<Button> buttons = new List<Button>();
                     buttons.AddRange(rewardSelectModel.RewardContentModels.Select(q => q.GetComponent<Button>()));
                     buttons.Add(gameSelectButtonModel.GetComponent<Button>());
+                    buttons.Add(gameTitleButtonModel.GetComponent <Button>());
                     currentButton = buttons
                         .FirstOrDefault(y => y == x.GetComponent<Button>());
                 });
@@ -161,5 +165,14 @@ namespace Main.Model
             /// <summary>次へ</summary>
             Next = 1,
         }
+    }
+
+    /// <summary>
+    /// MIDIJack用
+    /// イベントシステム
+    /// インターフェース
+    /// </summary>
+    public interface IEventSystemMidiJackModel
+    {
     }
 }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/GameTitleButtonModel.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/GameTitleButtonModel.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+namespace Main.Model
+{
+    /// <summary>
+    /// モデル
+    /// タイトルへ戻るボタン
+    /// </summary>
+    [RequireComponent(typeof(Button))]
+    [RequireComponent(typeof(EventTrigger))]
+
+    public class GameTitleButtonModel : UIEventController, IButtonEventTriggerModel
+    {
+        /// <summary>ボタン</summary>
+        private Button _button;
+        /// <summary>イベントトリガー</summary>
+        private EventTrigger _eventTrigger;
+        /// <summary>トランスフォーム</summary>
+        private Transform _transform;
+        /// <summary>トランスフォーム</summary>
+        public Transform Transform => _transform != null ? _transform : _transform = transform;
+
+        public bool SetButtonEnabled(bool enabled)
+        {
+            return _mainUGUIsModelUtility.SetButtonEnabledOfButton(enabled, _button, Transform);
+        }
+
+        public bool SetEventTriggerEnabled(bool enabled)
+        {
+            return _mainUGUIsModelUtility.SetEventTriggerEnabledOfEventTrigger(enabled, _eventTrigger, Transform);
+        }
+    }
+
+}
+

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/GameTitleButtonModel.cs.meta
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/GameTitleButtonModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5eb34d1c3a6187842bead1e2cb27ae9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameOverView.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameOverView.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Main.View
+{
+    /// <summary>
+    /// ビュー
+    /// ゲームオーバー画面
+    /// </summary>
+    public class GameOverView : MonoBehaviour, IGameOverView
+    {
+        private void OnEnable()
+        {
+            Time.timeScale = 0f;
+            Debug.LogWarning($"Time.timeScale:[{Time.timeScale}]");
+        }
+
+        private void OnDisable()
+        {
+            Time.timeScale = 1f;
+            Debug.LogWarning($"Time.timeScale:[{Time.timeScale}]");
+        }
+
+        public bool SetActiveGameObject(bool active)
+        {
+            try
+            {
+                gameObject.SetActive(active);
+
+                return true;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError(e);
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ビュー
+    /// ゲームオーバー画面
+    /// インターフェース
+    /// </summary>
+    public interface IGameOverView
+    {
+        /// <summary>
+        /// ゲームオブジェクトの有効／無効をセット
+        /// </summary>
+        /// <param name="active">有効／無効状態</param>
+        /// <returns>成功／失敗</returns>
+        public bool SetActiveGameObject(bool active);
+    }
+
+}

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameOverView.cs.meta
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameOverView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b54aa291512bcd040b52420755aa0c49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameTitleButtonView.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameTitleButtonView.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Main.View
+{
+    /// <summary>
+    /// ビュー
+    /// タイトルに戻るボタン
+    /// </summary>
+    public class GameTitleButtonView : MonoBehaviour
+    {
+    }
+}

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameTitleButtonView.cs.meta
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/GameTitleButtonView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efcdb478d7bdd6a4fbd15c49489cd69b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/PentagramTurnTableView.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/View/PentagramTurnTableView.cs
@@ -30,10 +30,13 @@ namespace Main.View
         {
             try
             {
-                if (!ControllAudio(bgmConfDetails))
-                    throw new System.Exception("ControllAudio");
-                float angle = bgmConfDetails.InputValue * angleCorrectionValue;
-                image.transform.Rotate(new Vector3(0f, 0f, angle));
+                if (0f < Time.timeScale)
+                {
+                    if (!ControllAudio(bgmConfDetails))
+                        throw new System.Exception("ControllAudio");
+                    float angle = bgmConfDetails.InputValue * angleCorrectionValue;
+                    image.transform.Rotate(new Vector3(0f, 0f, angle));
+                }
                 return true;
             }
             catch (System.Exception e)

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Universal/Scripts/Accessory/ResourcesAccessory.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Universal/Scripts/Accessory/ResourcesAccessory.cs
@@ -170,6 +170,8 @@ namespace Universal.Accessory
             {
                 continues.sceneId = defaults.sceneId;
                 continues.state = defaults.state;
+                continues.pentagramTurnTableInfo = defaults.pentagramTurnTableInfo;
+                continues.soulMoney = defaults.soulMoney;
 
                 return continues;
             }

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Universal/Scripts/Bean/UserBean.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Universal/Scripts/Bean/UserBean.cs
@@ -64,6 +64,254 @@ namespace Universal.Bean
         /// </summary>
         public int vibrationEnableIndex = 0;
 
+        private readonly PentagramTurnTableInfo PENTAGRAM_TURN_TABLE_INFO_DEFAULT = new PentagramTurnTableInfo()
+        {
+            slots = new PentagramTurnTableInfo.Slot[]
+            {
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 0,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 3,
+                        genomeType = 0,
+                        name = "朱雀",
+                        type = 1,
+                        slotId = 0,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 6,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 1,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 12,
+                        genomeType = 0,
+                        name = "晴明",
+                        type = 3,
+                        slotId = 1,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 2,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 0,
+                        genomeType = 0,
+                        name = "勾陳",
+                        type = 2,
+                        slotId = 2,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 6,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 7,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 3,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 1,
+                        genomeType = 0,
+                        name = "六合",
+                        type = 0,
+                        slotId = 3,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 4,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 12,
+                        genomeType = 0,
+                        name = "晴明",
+                        type = 3,
+                        slotId = 4,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+            }
+        };
+
+        private readonly PentagramTurnTableInfo PENTAGRAM_TURN_TABLE_INFO_DEFAULT_2 = new PentagramTurnTableInfo()
+        {
+            slots = new PentagramTurnTableInfo.Slot[]
+            {
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 1,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 12,
+                        genomeType = 0,
+                        name = "晴明",
+                        type = 3,
+                        slotId = 1,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+                new PentagramTurnTableInfo.Slot()
+                {
+                    slotId = 4,
+                    shikigamiInfo = new ShikigamiInfo()
+                    {
+                        characterID = 12,
+                        genomeType = 0,
+                        name = "晴明",
+                        type = 3,
+                        slotId = 4,
+                        level = 1,
+                        mainSkills = new ShikigamiInfo.MainSkill[]
+                        {
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 1,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 3,
+                                rank = 0,
+                            },
+                            new ShikigamiInfo.MainSkill()
+                            {
+                                type = 2,
+                                rank = 0,
+                            },
+                        },
+                        subSkills = new ShikigamiInfo.SubSkill[0],
+                    }
+                },
+            }
+        };
+
         public PentagramTurnTableInfo pentagramTurnTableInfo = new PentagramTurnTableInfo()
         {
             slots = new PentagramTurnTableInfo.Slot[]
@@ -127,6 +375,7 @@ namespace Universal.Bean
 
         /// <summary>魂のお金</summary>
         public int soulMoney = 0;
+        private readonly int SOUL_MONEY = 0;
         /// <summary>入力モード</summary>
         public int inputMode = 0;
 
@@ -142,6 +391,10 @@ namespace Universal.Bean
                 case EnumLoadMode.Default:
                     sceneId = SCENEID_DEFAULT;
                     state = STATE_DEFAULT;
+                    // TODO: デフォルトは結局どちらなのか
+                    // PENTAGRAM_TURN_TABLE_INFO_DEFAULT / PENTAGRAM_TURN_TABLE_INFO_DEFAULT_2
+                    pentagramTurnTableInfo = PENTAGRAM_TURN_TABLE_INFO_DEFAULT;
+                    soulMoney = SOUL_MONEY;
 
                     break;
                 case EnumLoadMode.All:


### PR DESCRIPTION
　●【神ゲー3次審査】ゲームオーバー画面の実装

▼共通連携
　●メイン
　　○メインシーン（MainScene.unity）にて、MidiJackイベントシステム、五芒星、キャンバスへゲームオーバーの追加 　　○メインキャンバス（Canvas.prefab）にて、ゲームオーバーの画面を追加
　　○MidiJackイベントシステムプレハブ（EventSystemMidiJack.prefab）にて、タイトルへ戻るボタンを追加 　　○五芒星テーブルプレハブ（PentagramTurnTable.prefab）にて、HPに影響を受けず一定の見た目にする修正 　　○メインプレゼンタ（MainPresenter.cs）にて、ゲームオーバーの対応、ゲームオーバーの画面でポーズを出さない、最終ステージでゲームオーバー対応 　●ユニバーサル
　　○ユーザデータビーン（UserBean.cs）へデフォルトのユーザデータをセット、データ初期化対応