### PR TITLE
テストプレイの結果を反映

### DIFF
--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy03Konkon.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy03Konkon.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.hpMax
-      value: 1000
+      value: 800
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: enemiesProp.soulMoneyPoint

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy04Peraperabo.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy04Peraperabo.prefab
@@ -58,7 +58,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.moveSpeed
-      value: 0.1
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: enemiesProp.soulMoneyPoint

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy05Shackshineko.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy05Shackshineko.prefab
@@ -58,7 +58,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.moveSpeed
-      value: 0.1
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: enemiesProp.soulMoneyPoint

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy12Momonkabe.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy12Momonkabe.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.hpMax
-      value: 500
+      value: 1500
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.moveSpeed

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy13Momentomori.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/Level/Enemies/Normal/Enemy13Momentomori.prefab
@@ -54,7 +54,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.hpMax
-      value: 1000
+      value: 2500
       objectReference: {fileID: 0}
     - target: {fileID: 3678280287336115840, guid: 5d7044c8d42de1540a3954615dee3f19, type: 3}
       propertyPath: prop.moveSpeed

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/MainGameManager.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/MainGameManager.prefab
@@ -132,11 +132,11 @@ MonoBehaviour:
     image: {fileID: 21300000, guid: bfa93a3222f4740469acb95016ea06e7, type: 3}
   enhanceProps:
   - level: 1
-    soulMoney: 300
+    soulMoney: 200
   - level: 2
-    soulMoney: 500
+    soulMoney: 400
   - level: 3
-    soulMoney: 800
+    soulMoney: 600
   subSkillsSynergies:
   - subSkillType: 1
     subSkillTags: 00000000

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/ShikigamiSkillSystem.prefab
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Prefabs/ShikigamiSkillSystem.prefab
@@ -59,3 +59,5 @@ MonoBehaviour:
   - 3
   onmyoSlipLoopRate: 15
   pentagramTurnTableScriptableObject: {fileID: 11400000, guid: e093617fc1a2b024983809efd80547c1, type: 2}
+  onmyoSlipLoopEnergy: 2
+  onmyoSlipLoopResetTime: 5

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/BgmPlayer.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Audio/BgmPlayer.cs
@@ -93,7 +93,8 @@ namespace Main.Audio
                     audioSource.loop = sceneId == 8;
 
                     // BGMを再生
-                    audioSource.Play();
+                    if(audioSource.loop = sceneId != 0)
+                        audioSource.Play();
                 }
                 else
                     throw new System.Exception($"対象のファイルが見つかりません:[{clipToPlay}]");

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/DamageSufferedZoneOfEnemyModel.cs
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/Main/Scripts/Model/DamageSufferedZoneOfEnemyModel.cs
@@ -74,10 +74,10 @@ namespace Main.Model
                 if (_utility.IsCompareTagAndUpdateReactiveFlagPublic(other, tags, IsHit, shikigamiType))
                     SetBadStatus(onmyoBulletConfig.subSkillType, onmyoBulletConfig.subSkillValue);
 
-                base.OnTriggerEnter2DGraff(other, 100.0f);
+                base.OnTriggerEnter2DGraff(other, 50.0f);
             }
             else
-                base.OnTriggerEnter2DGraff(other, 100.0f);
+                base.OnTriggerEnter2DGraff(other, 50.0f);
         }
 
         protected override void OnDisable()

--- a/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/SaveDatas/AdminData.json
+++ b/DJ_Onmyoji_AKA_AbeNoSeimei/Assets/SaveDatas/AdminData.json
@@ -359,25 +359,25 @@
 				"shikigamiType": 1,
 				"mainSkillType": 6,
 				"skillRank": 4,
-				"value": 3.0
-			},
-			{
-				"shikigamiType": 1,
-				"mainSkillType": 6,
-				"skillRank": 3,
-				"value": 2.5
-			},
-			{
-				"shikigamiType": 1,
-				"mainSkillType": 6,
-				"skillRank": 2,
 				"value": 2.0
 			},
 			{
 				"shikigamiType": 1,
 				"mainSkillType": 6,
-				"skillRank": 1,
+				"skillRank": 3,
+				"value": 1.75
+			},
+			{
+				"shikigamiType": 1,
+				"mainSkillType": 6,
+				"skillRank": 2,
 				"value": 1.5
+			},
+			{
+				"shikigamiType": 1,
+				"mainSkillType": 6,
+				"skillRank": 1,
+				"value": 1.25
 			},
 			{
 				"shikigamiType": 1,
@@ -389,28 +389,28 @@
 				"shikigamiType": 2,
 				"mainSkillType": 1,
 				"skillRank": 4,
-				"value": 0.4,
-                "valueBuffMax": 1.5
-			},
-			{
-				"shikigamiType": 2,
-				"mainSkillType": 1,
-				"skillRank": 3,
-				"value": 0.5,
-                "valueBuffMax": 1.5
-			},
-			{
-				"shikigamiType": 2,
-				"mainSkillType": 1,
-				"skillRank": 2,
 				"value": 0.6,
                 "valueBuffMax": 1.5
 			},
 			{
 				"shikigamiType": 2,
 				"mainSkillType": 1,
-				"skillRank": 1,
+				"skillRank": 3,
+				"value": 0.7,
+                "valueBuffMax": 1.5
+			},
+			{
+				"shikigamiType": 2,
+				"mainSkillType": 1,
+				"skillRank": 2,
 				"value": 0.8,
+                "valueBuffMax": 1.5
+			},
+			{
+				"shikigamiType": 2,
+				"mainSkillType": 1,
+				"skillRank": 1,
+				"value": 0.9,
                 "valueBuffMax": 1.5
 			},
 			{
@@ -430,25 +430,25 @@
 				"shikigamiType": 2,
 				"mainSkillType": 6,
 				"skillRank": 4,
-				"value": 3.0
-			},
-			{
-				"shikigamiType": 2,
-				"mainSkillType": 6,
-				"skillRank": 3,
-				"value": 2.5
-			},
-			{
-				"shikigamiType": 2,
-				"mainSkillType": 6,
-				"skillRank": 2,
 				"value": 2.0
 			},
 			{
 				"shikigamiType": 2,
 				"mainSkillType": 6,
-				"skillRank": 1,
+				"skillRank": 3,
+				"value": 1.75
+			},
+			{
+				"shikigamiType": 2,
+				"mainSkillType": 6,
+				"skillRank": 2,
 				"value": 1.5
+			},
+			{
+				"shikigamiType": 2,
+				"mainSkillType": 6,
+				"skillRank": 1,
+				"value": 1.25
 			},
 			{
 				"shikigamiType": 2,
@@ -792,31 +792,31 @@
         "shikigamiType": 2,
         "subSkillType": 11,
         "skillRank": 0,
-        "value": 200.0
+        "value": 100.0
       },
       {
         "shikigamiType": 2,
         "subSkillType": 11,
         "skillRank": 1,
-        "value": 300.0
+        "value": 150.0
       },
       {
         "shikigamiType": 2,
         "subSkillType": 11,
         "skillRank": 2,
-        "value": 400.0
+        "value": 200.0
       },
       {
         "shikigamiType": 2,
         "subSkillType": 11,
         "skillRank": 3,
-        "value": 500.0
+        "value": 250.0
       },
       {
         "shikigamiType": 2,
         "subSkillType": 11,
         "skillRank": 4,
-        "value": 600.0
+        "value": 300.0
       },
       {
         "shikigamiType": 2,
@@ -1520,7 +1520,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1568,7 +1568,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1616,7 +1616,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1664,7 +1664,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1712,7 +1712,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1760,7 +1760,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1808,7 +1808,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1856,7 +1856,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1904,7 +1904,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -1952,7 +1952,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -2000,7 +2000,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             },
             {
                 "rewardType": 1,
@@ -2048,7 +2048,7 @@
                         }
                     ]
                 },
-                "soulMoney": 800
+                "soulMoney": 600
             }
         ]
                           },


### PR DESCRIPTION
１．ループの消費SPを半分に＆ループ消費量のリセット時間を30Sec→5Secに
　→ループを使いこなすのは制作者でも難しい。ハードルを下げるために消費SPや制限を大幅ダウン
２．各式神強化の必要ソウルを２００、４００、６００に
　→昼のみだと１ステージ５００くらいしか溜まらない。ある程度強化してほしいので、一律ダウン
　（テストプレイで夜までやってくれる人は少ないと思うので）
３．敵のパラメータ調整
　コンコン：HPを１０００→８００へ（序盤の割に固くてしんどい）
　シャクシネコ＆ペラペラボー：移動速度を０．１→０．２へ（遅すぎて脅威にならない）
　モモンカベとモメントモリ：HPを大幅増加（最終ステージの割にHPが低すぎたので）
４．グラフィティを弱体化
　デフォルトのダメージを１００→５０に弱体化
　範囲強化の最大値を３．０→２．０へ弱体化（３．０広すぎ）
　連射強化の最大値を０．４→０．６へ弱体化（範囲攻撃がこの速度はやべぇ）
５．ダンスを少し弱体化
　範囲強化の最大値を３．０→２．０へ弱体化